### PR TITLE
Add workflow to auto-merge dev to main after Version Packages PR

### DIFF
--- a/.changeset/auto-promote-workflow.md
+++ b/.changeset/auto-promote-workflow.md
@@ -1,0 +1,5 @@
+---
+"maze": patch
+---
+
+Add workflow to auto-merge dev to main after Version Packages PR is merged

--- a/.github/workflows/promote-to-main.yml
+++ b/.github/workflows/promote-to-main.yml
@@ -1,0 +1,46 @@
+# Automatically merges dev into main after a "Version Packages" PR is merged
+# This completes the release process - Vercel will auto-deploy main to production
+name: Promote to Main
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [dev]
+  # Keep manual trigger as backup
+  workflow_dispatch:
+
+jobs:
+  promote:
+    name: Merge dev to main
+    runs-on: ubuntu-latest
+    # Only run if PR was merged (not just closed) AND is a Version Packages PR
+    # For workflow_dispatch, always run
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.merged == true &&
+       contains(github.event.pull_request.title, 'Version Packages'))
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Merge dev into main
+        run: |
+          git checkout main
+          git pull origin main
+          git merge origin/dev --no-edit
+          git push origin main
+
+      - name: Summary
+        run: |
+          echo "✅ Successfully merged dev into main"
+          echo "🚀 Vercel will now deploy to production"


### PR DESCRIPTION
## Summary
- Adds `promote-to-main.yml` workflow that automatically merges `dev` into `main` when a "Version Packages" PR is merged
- Eliminates the need for a second manual step after approving a release
- Includes manual `workflow_dispatch` trigger as backup

## New Release Flow
1. Features merged to `dev` with changesets
2. `release.yml` creates "Version Packages" PR → `dev`
3. You merge that PR (manual approval gate)
4. **New:** `promote-to-main.yml` auto-triggers and merges `dev` → `main`
5. Vercel deploys `main` to production

🤖 Generated with [Claude Code](https://claude.com/claude-code)