### PR TITLE
Rename promote-to-main workflow to deploy

### DIFF
--- a/.changeset/rename-deploy-workflow.md
+++ b/.changeset/rename-deploy-workflow.md
@@ -1,0 +1,5 @@
+---
+'maze': patch
+---
+
+Rename promote-to-main workflow to deploy for clarity

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,6 @@
 # Automatically merges dev into main after a "Version Packages" PR is merged
 # This completes the release process - Vercel will auto-deploy main to production
-name: Promote to Main
+name: Deploy
 
 on:
   pull_request:


### PR DESCRIPTION
## Summary
- Rename `.github/workflows/promote-to-main.yml` to `deploy.yml`
- Update workflow name from "Promote to Main" to "Deploy"
- Aligns naming with the existing `release.yml` (changesets) workflow

## Test plan
- [ ] Verify workflow file is renamed correctly
- [ ] Verify workflow triggers on Version Packages PR merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)